### PR TITLE
Fix validation in ModeloClientes

### DIFF
--- a/src/main/java/dam/di/enoteca/modelo/ModeloClientes.java
+++ b/src/main/java/dam/di/enoteca/modelo/ModeloClientes.java
@@ -20,12 +20,16 @@ public class ModeloClientes {
     }
 
     public void agregarCliente(Cliente cliente) {
-        if (cliente == null || cliente.toString().trim().isEmpty()) {
+        if (cliente == null
+                || cliente.getNombre() == null || cliente.getNombre().trim().isEmpty()
+                || cliente.getDireccion() == null || cliente.getDireccion().trim().isEmpty()
+                || cliente.getCorreo() == null || cliente.getCorreo().trim().isEmpty()
+                || cliente.getTelefono() == null || cliente.getTelefono().trim().isEmpty()) {
             throw new IllegalArgumentException("El cliente no puede ser nulo ni vacío.");
         } else {
             clientes.add(cliente);
-        }        
-    }        
+        }
+    }
         
     public List<Cliente> obtenerClientes() {
         return clientes;

--- a/src/test/java/tareaPresencial/EnotecaTest.java
+++ b/src/test/java/tareaPresencial/EnotecaTest.java
@@ -36,5 +36,15 @@ public class EnotecaTest {
         });        
         assertEquals("EL correo a eliminar no puede ser nulo ni vacío.", exception.getMessage());
     }
+
+    @Test
+    void nuevoClienteUnSuccessfully(){
+        ModeloClientes mc = new ModeloClientes();
+        Cliente invalido = new Cliente("", "", null, "");
+        Exception exception = assertThrows(Exception.class, () -> {
+            mc.agregarCliente(invalido);
+        });
+        assertEquals("El cliente no puede ser nulo ni vacío.", exception.getMessage());
+    }
     
 }


### PR DESCRIPTION
## Summary
- strengthen validation when adding new Cliente
- test invalid Cliente creation in EnotecaTest

## Testing
- `mvn test` *(fails: PluginResolutionException - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_683f3ca14f14832da73291c6fc04a304