### PR TITLE
Fix label typo in client panel

### DIFF
--- a/src/main/java/dam/di/enoteca/vista/JPanelClientes.form
+++ b/src/main/java/dam/di/enoteca/vista/JPanelClientes.form
@@ -67,7 +67,7 @@
     </Component>
     <Component class="javax.swing.JButton" name="jButtonBorrarCliente">
       <Properties>
-        <Property name="text" type="java.lang.String" value="Borarr Cliente"/>
+          <Property name="text" type="java.lang.String" value="Borrar Cliente"/>
       </Properties>
       <Events>
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jButtonBorrarClienteActionPerformed"/>

--- a/src/main/java/dam/di/enoteca/vista/JPanelClientes.java
+++ b/src/main/java/dam/di/enoteca/vista/JPanelClientes.java
@@ -69,7 +69,7 @@ public class JPanelClientes extends javax.swing.JPanel {
             }
         });
 
-        jButtonBorrarCliente.setText("Borarr Cliente");
+        jButtonBorrarCliente.setText("Borrar Cliente");
         jButtonBorrarCliente.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 jButtonBorrarClienteActionPerformed(evt);


### PR DESCRIPTION
## Summary
- correct typo on delete client button

## Testing
- `mvn -q test` *(fails: jacoco plugin not resolved)*

------
https://chatgpt.com/codex/tasks/task_e_683f3fd0f230832d9a479b9b200c821f