### PR TITLE
Add check for list size after failed deletion

### DIFF
--- a/src/test/java/tareaPresencial/EnotecaTest.java
+++ b/src/test/java/tareaPresencial/EnotecaTest.java
@@ -33,8 +33,10 @@ public class EnotecaTest {
         assertEquals(1, mc.obtenerClientes().size());
         Exception exception = assertThrows(Exception.class, () -> {
             mc.eliminarCliente(null);
-        });        
+        });
         assertEquals("EL correo a eliminar no puede ser nulo ni vacío.", exception.getMessage());
+        // After a failed deletion attempt the list should remain unchanged
+        assertEquals(1, mc.obtenerClientes().size());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- ensure the client list remains unchanged when deletion fails

## Testing
- `mvn -q test` *(fails: Could not resolve jacoco-maven-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_683f3f8d3df4832d932392138d95fa76